### PR TITLE
Refactor async workflows and improve media handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,4 +65,10 @@ dependencies {
 
   // Optional image previews
   implementation("io.coil-kt:coil-compose:2.7.0")
+
+  // HTML parsing
+  implementation("org.jsoup:jsoup:1.17.2")
+
+  // Testing
+  testImplementation("junit:junit:4.13.2")
 }

--- a/app/src/main/java/com/mrunicorn/sb/data/ItemQuery.kt
+++ b/app/src/main/java/com/mrunicorn/sb/data/ItemQuery.kt
@@ -1,0 +1,5 @@
+package com.mrunicorn.sb.data
+
+enum class ItemFilter { All, Links, Text, Images }
+
+enum class ItemSort { Date, Name, Label }

--- a/app/src/main/java/com/mrunicorn/sb/reminder/ReminderReceiver.kt
+++ b/app/src/main/java/com/mrunicorn/sb/reminder/ReminderReceiver.kt
@@ -11,13 +11,11 @@ import androidx.core.app.NotificationCompat
 import com.mrunicorn.sb.ui.MainActivity
 import com.mrunicorn.sb.R
 import com.mrunicorn.sb.App
-import com.mrunicorn.sb.data.Item
 import com.mrunicorn.sb.data.ItemType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import android.graphics.BitmapFactory
-import android.net.Uri
 
 class ReminderReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
@@ -26,49 +24,49 @@ class ReminderReceiver : BroadcastReceiver() {
         val deleteAfterReminder = intent.getBooleanExtra("deleteAfterReminder", false)
         val label = intent.getStringExtra("label")
 
-        val channelId = "reminders"
-        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            nm.createNotificationChannel(
-                NotificationChannel(channelId, "Reminders", NotificationManager.IMPORTANCE_DEFAULT)
-            )
-        }
-
-        val open = Intent(context, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            putExtra("openItemId", itemId)
-        }
-        val pi = PendingIntent.getActivity(context, itemId.hashCode(), open, PendingIntent.FLAG_IMMUTABLE)
-
-        val notificationBuilder = NotificationCompat.Builder(context, channelId)
-            .setSmallIcon(R.drawable.ic_notify)
-            .setContentTitle(label ?: "Reminder")
-            .setContentText(title)
-            .setAutoCancel(true)
-            .setContentIntent(pi)
-
-        // Load mini thumbnail
+        val pendingResult = goAsync()
         val repo = (context.applicationContext as App).repo
         CoroutineScope(Dispatchers.IO).launch {
-            val item = repo.dao.getItemById(itemId)
-            if (item != null && item.type == ItemType.IMAGE && item.imageUris.isNotEmpty()) {
-                try {
-                    val imageUri = item.imageUris.first()
-                    val bitmap = BitmapFactory.decodeStream(context.contentResolver.openInputStream(imageUri))
-                    notificationBuilder.setLargeIcon(bitmap)
-                } catch (e: Exception) {
-                    e.printStackTrace()
+            try {
+                val channelId = "reminders"
+                val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    nm.createNotificationChannel(
+                        NotificationChannel(channelId, "Reminders", NotificationManager.IMPORTANCE_DEFAULT)
+                    )
                 }
-            }
-            nm.notify(itemId.hashCode(), notificationBuilder.build())
-        }
 
-        if (deleteAfterReminder) {
-            // Deletion is now handled within the CoroutineScope after notification is built
-            // to ensure the item is available for thumbnail loading.
-            // The deletion will happen after the notification is shown.
-            CoroutineScope(Dispatchers.IO).launch {
-                repo.delete(itemId)
+                val open = Intent(context, MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    putExtra("openItemId", itemId)
+                }
+                val pi = PendingIntent.getActivity(context, itemId.hashCode(), open, PendingIntent.FLAG_IMMUTABLE)
+
+                val notificationBuilder = NotificationCompat.Builder(context, channelId)
+                    .setSmallIcon(R.drawable.ic_notify)
+                    .setContentTitle(label ?: "Reminder")
+                    .setContentText(title)
+                    .setAutoCancel(true)
+                    .setContentIntent(pi)
+
+                val item = repo.dao.getItemById(itemId)
+                if (item != null && item.type == ItemType.IMAGE && item.imageUris.isNotEmpty()) {
+                    try {
+                        val imageUri = item.imageUris.first()
+                        val bitmap = BitmapFactory.decodeStream(context.contentResolver.openInputStream(imageUri))
+                        notificationBuilder.setLargeIcon(bitmap)
+                    } catch (e: Exception) {
+                        e.printStackTrace()
+                    }
+                }
+
+                nm.notify(itemId.hashCode(), notificationBuilder.build())
+
+                if (deleteAfterReminder) {
+                    repo.delete(itemId)
+                }
+            } finally {
+                pendingResult.finish()
             }
         }
     }

--- a/app/src/main/java/com/mrunicorn/sb/ui/MainActivity.kt
+++ b/app/src/main/java/com/mrunicorn/sb/ui/MainActivity.kt
@@ -22,12 +22,17 @@ import androidx.lifecycle.lifecycleScope
 import com.mrunicorn.sb.App
 import com.mrunicorn.sb.data.Item
 import com.mrunicorn.sb.data.ItemType
+import com.mrunicorn.sb.data.ItemFilter
+import com.mrunicorn.sb.data.ItemSort
+import com.mrunicorn.sb.data.Repository
 import com.mrunicorn.sb.ui.theme.ShareBuddyTheme
 import androidx.compose.material3.ExperimentalMaterial3Api
 import coil.compose.AsyncImage
 import androidx.compose.ui.layout.ContentScale
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class MainActivity : ComponentActivity() {
     private val repo by lazy { (application as App).repo }
@@ -42,8 +47,8 @@ class MainActivity : ComponentActivity() {
         setContent {
             ShareBuddyTheme {
                 var query by remember { mutableStateOf("") }
-                var filter by remember { mutableStateOf<Filter>(Filter.All) }
-                var sortBy by remember { mutableStateOf<SortBy>(SortBy.Date) }
+                var filter by remember { mutableStateOf(ItemFilter.All) }
+                var sortBy by remember { mutableStateOf(ItemSort.Date) }
                 val items = remember { mutableStateListOf<Item>() }
                 val lazyListState = rememberLazyListState()
                 var showAllItems by remember { mutableStateOf(false) }
@@ -52,21 +57,11 @@ class MainActivity : ComponentActivity() {
 
                 LaunchedEffect(query, filter, sortBy) {
                     repo.inbox(query.ifBlank { null }).collectLatest { list ->
-                        val sortedList = when (sortBy) {
-                            SortBy.Date -> list.sortedByDescending { it.createdAt }
-                            SortBy.Name -> list.sortedBy { it.text ?: "" }
-                            SortBy.Label -> list.sortedBy { it.label ?: "" }
+                        val processed = withContext(Dispatchers.Default) {
+                            Repository.sortAndFilter(list, filter, sortBy)
                         }
-
                         items.clear()
-                        items.addAll(
-                            when (filter) {
-                                Filter.All -> sortedList
-                                Filter.Links -> sortedList.filter { it.type == ItemType.LINK }
-                                Filter.Text -> sortedList.filter { it.type == ItemType.TEXT }
-                                Filter.Images -> sortedList.filter { it.type == ItemType.IMAGE }
-                            }
-                        )
+                        items.addAll(processed)
                         val openItemId = intent.getStringExtra("openItemId")
                         if (openItemId != null) {
                             val index = items.indexOfFirst { it.id == openItemId }
@@ -92,16 +87,16 @@ class MainActivity : ComponentActivity() {
                         )
                         Spacer(Modifier.height(12.dp))
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            FilterChip(selected = filter == Filter.All, onClick = { filter = Filter.All }, label = { Text("All") })
-                            FilterChip(selected = filter == Filter.Links, onClick = { filter = Filter.Links }, label = { Text("Links") })
-                            FilterChip(selected = filter == Filter.Text, onClick = { filter = Filter.Text }, label = { Text("Text") })
-                            FilterChip(selected = filter == Filter.Images, onClick = { filter = Filter.Images }, label = { Text("Images") })
+                            FilterChip(selected = filter == ItemFilter.All, onClick = { filter = ItemFilter.All }, label = { Text("All") })
+                            FilterChip(selected = filter == ItemFilter.Links, onClick = { filter = ItemFilter.Links }, label = { Text("Links") })
+                            FilterChip(selected = filter == ItemFilter.Text, onClick = { filter = ItemFilter.Text }, label = { Text("Text") })
+                            FilterChip(selected = filter == ItemFilter.Images, onClick = { filter = ItemFilter.Images }, label = { Text("Images") })
                         }
                         Spacer(Modifier.height(12.dp))
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            FilterChip(selected = sortBy == SortBy.Date, onClick = { sortBy = SortBy.Date }, label = { Text("Date") })
-                            FilterChip(selected = sortBy == SortBy.Name, onClick = { sortBy = SortBy.Name }, label = { Text("Name") })
-                            FilterChip(selected = sortBy == SortBy.Label, onClick = { sortBy = SortBy.Label }, label = { Text("Label") })
+                            FilterChip(selected = sortBy == ItemSort.Date, onClick = { sortBy = ItemSort.Date }, label = { Text("Date") })
+                            FilterChip(selected = sortBy == ItemSort.Name, onClick = { sortBy = ItemSort.Name }, label = { Text("Name") })
+                            FilterChip(selected = sortBy == ItemSort.Label, onClick = { sortBy = ItemSort.Label }, label = { Text("Label") })
                         }
                         Spacer(Modifier.height(12.dp))
                         if (items.isEmpty()) {
@@ -199,10 +194,6 @@ fun LabelDialog(item: Item, onDismiss: () -> Unit, onConfirm: (Item, String?) ->
         }
     )
 }
-
-enum class Filter { All, Links, Text, Images }
-
-enum class SortBy { Date, Name, Label }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/test/java/com/mrunicorn/sb/data/RepositorySortFilterTest.kt
+++ b/app/src/test/java/com/mrunicorn/sb/data/RepositorySortFilterTest.kt
@@ -1,0 +1,25 @@
+package com.mrunicorn.sb.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RepositorySortFilterTest {
+    private val items = listOf(
+        Item(id = "1", type = ItemType.TEXT, text = "b", createdAt = 2),
+        Item(id = "2", type = ItemType.TEXT, text = "a", createdAt = 3),
+        Item(id = "3", type = ItemType.LINK, text = "c", createdAt = 1)
+    )
+
+    @Test
+    fun sortsByName() {
+        val sorted = Repository.sortAndFilter(items, ItemFilter.All, ItemSort.Name)
+        assertEquals(listOf("a", "b", "c"), sorted.map { it.text })
+    }
+
+    @Test
+    fun filtersLinks() {
+        val filtered = Repository.sortAndFilter(items, ItemFilter.Links, ItemSort.Date)
+        assertEquals(1, filtered.size)
+        assertEquals(ItemType.LINK, filtered.first().type)
+    }
+}

--- a/app/src/test/java/com/mrunicorn/sb/util/LinkThumbnailExtractorTest.kt
+++ b/app/src/test/java/com/mrunicorn/sb/util/LinkThumbnailExtractorTest.kt
@@ -1,0 +1,50 @@
+package com.mrunicorn.sb.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LinkThumbnailExtractorTest {
+    @Test
+    fun extractsFromDoubleQuotes() {
+        val html = """
+            <html><head>
+            <meta property="og:image" content="http://example.com/a.jpg">
+            </head><body></body></html>
+        """.trimIndent()
+        val url = LinkThumbnailExtractor.parseThumbnailFromHtml(html)
+        assertEquals("http://example.com/a.jpg", url)
+    }
+
+    @Test
+    fun extractsFromSingleQuotes() {
+        val html = """
+            <html><head>
+            <meta property='og:image' content='http://example.com/b.png'>
+            </head><body></body></html>
+        """.trimIndent()
+        val url = LinkThumbnailExtractor.parseThumbnailFromHtml(html)
+        assertEquals("http://example.com/b.png", url)
+    }
+
+    @Test
+    fun resolvesRelativeUrl() {
+        val html = """
+            <html><head>
+            <meta content="/img/c.webp" property="og:image" />
+            </head><body></body></html>
+        """.trimIndent()
+        val url = LinkThumbnailExtractor.parseThumbnailFromHtml(html, "http://example.com")
+        assertEquals("http://example.com/img/c.webp", url)
+    }
+
+    @Test
+    fun readsTwitterImage() {
+        val html = """
+            <html><head>
+            <meta name="twitter:image" content="http://example.com/d.jpg" />
+            </head><body></body></html>
+        """.trimIndent()
+        val url = LinkThumbnailExtractor.parseThumbnailFromHtml(html)
+        assertEquals("http://example.com/d.jpg", url)
+    }
+}


### PR DESCRIPTION
## Summary
- use Jsoup for robust thumbnail parsing and add unit tests
- preserve original image formats when saving and centralize sort/filter logic
- tie reminder notifications to broadcast lifecycle with `goAsync`
- expose HTML parsing helper for tests and expand coverage for Twitter image metadata

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aac3a09dbc8323911d6805ed3a29bb